### PR TITLE
Fix markdown titles in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 # under the License.
 #
 -->
-##Zephyr For JIRA connector for Jenkins (zfj-jenkins)
-###About the Plugin
+## Zephyr For JIRA connector for Jenkins (zfj-jenkins)
+### About the Plugin
 
 
 Please refer to Zephyr Support <a href="https://wiki.jenkins.io/display/JENKINS/Zephyr+For+Jira+Test+Management+Plugin">Knowledge Base</a>


### PR DESCRIPTION
Fixing the title in the README so first two titles show up appropriately rendered on github.

Before this change, ##'s would appear in the readme's display